### PR TITLE
Yaml anchors support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ You also need:
 Should initially have created the file with another extension such as `.txt`, make sure to change the format to
 `YAML` and the right schema should then be picked up.
 
+### YAML Anchors
+
+You may use YAML anchors as demonnstrated below.
+
+    # Schema: Parity PR Documentation Schema (prdoc)
+
+    # Anchoring is NOT supported yet.
+
+    title: Foobar
+
+    doc:
+      - audience: Builder
+        description: &desc |
+          Sunt voluptate ad duis consequat ea in dolore non adipisicing incididunt
+          ullamco enim qui enim.
+
+      - audience: Validator
+        description: *desc
+
+    migrations:
+      db: []
+      runtime: []
+
+    crates: []
+    host_functions: []
+
 ## Usage
 
     prdoc is a cli utility to generate, check and load prdoc files.

--- a/doc/anchors.adoc
+++ b/doc/anchors.adoc
@@ -1,0 +1,8 @@
+
+=== YAML Anchors
+
+You may use YAML anchors as demonnstrated below.
+
+----
+include::../tests/data/all/pr_1244_anchoring.prdoc[]
+----

--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -1,6 +1,8 @@
 
 include::schema.adoc[]
 
+include::anchors.adoc[]
+
 include::cli/index.adoc[]
 
 include::docker.adoc[]

--- a/prdoclib/src/schema.rs
+++ b/prdoclib/src/schema.rs
@@ -44,7 +44,8 @@ impl Schema {
 		let json_schema: serde_json::Value = serde_json::from_str(&schema_str).unwrap();
 
 		let reader = File::open(file).unwrap();
-		let doc_as_yaml: serde_yaml::Value = serde_yaml::from_reader(reader).unwrap();
+		let mut doc_as_yaml: serde_yaml::Value = serde_yaml::from_reader(reader).unwrap();
+		doc_as_yaml.apply_merge().unwrap();
 
 		let doc_as_json: serde_json::Value =
 			serde_yaml::from_value(serde_yaml::to_value(&doc_as_yaml).unwrap()).unwrap();

--- a/tests/data/all/pr_1244_anchoring.prdoc
+++ b/tests/data/all/pr_1244_anchoring.prdoc
@@ -1,0 +1,21 @@
+# Schema: Parity PR Documentation Schema (prdoc)
+
+# Anchoring is NOT supported yet.
+
+title: Foobar
+
+doc:
+  - audience: Builder
+    description: &desc |
+      Sunt voluptate ad duis consequat ea in dolore non adipisicing incididunt
+      ullamco enim qui enim.
+
+  - audience: Validator
+    description: *desc
+
+migrations:
+  db: []
+  runtime: []
+
+crates: []
+host_functions: []

--- a/tests/data/all/pr_1244_anchoring.prdoc
+++ b/tests/data/all/pr_1244_anchoring.prdoc
@@ -1,7 +1,5 @@
 # Schema: Parity PR Documentation Schema (prdoc)
 
-# Anchoring is NOT supported yet.
-
 title: Foobar
 
 doc:


### PR DESCRIPTION
This PR adds YAML anchors support, allowing things like:

```
...
   doc:
      - audience: Builder
        description: &desc |
          Sunt voluptate ad duis consequat ea in dolore non adipisicing.

      - audience: Validator
        description: *desc
...
```
