### PR TITLE
Improve generate command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,12 @@ fn main() -> color_eyre::Result<()> {
 	match opts.subcmd {
 		Some(SubCommand::Generate(cmd_opts)) => {
 			debug!("cmd_opts: {cmd_opts:#?}");
-			match GenerateCmd::run(cmd_opts.save, cmd_opts.number, cmd_opts.title, cmd_opts.output_dir) {
+			let dir = match cmd_opts.output_dir {
+				Some(d) => d,
+				None => prdoclib::utils::get_pr_doc_folder().expect("Always have a default"),
+			};
+			debug!("PRDoc folder: {dir:?}");
+			match GenerateCmd::run(!cmd_opts.dry_run, cmd_opts.number, cmd_opts.title, Some(dir)) {
 				Ok(_) => Ok(()),
 				Err(e) => {
 					eprint!("{e:?}");

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -66,9 +66,10 @@ pub struct GenOpts {
 	#[clap(short, long)]
 	pub title: Option<Title>,
 
-	/// Save the generated document to file with the proper naming
+	/// Do not save the generated document to file with the proper naming, show the content
+	/// instead
 	#[clap(short, long)]
-	pub save: bool,
+	pub dry_run: bool,
 
 	/// Optional output directory. It not passed, the default `PRDOC_DIR` will be used
 	/// under the root of the current project.

--- a/cli/tests/check.rs
+++ b/cli/tests/check.rs
@@ -5,10 +5,10 @@ mod cli_tests {
 		use assert_cmd::Command;
 
 		#[test]
-		fn it_check_fails_without_args() {
+		fn it_check_passes_without_args() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("check").assert();
-			assert.failure().code(exitcode::DATAERR);
+			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
@@ -28,7 +28,7 @@ mod cli_tests {
 		#[test]
 		fn it_check_with_file_when_valid() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.args(["check", "-f", "../tests/data/some/pr_1234_some_test_minimal.prdoc"]).assert();
+			let assert = cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 

--- a/cli/tests/check.rs
+++ b/cli/tests/check.rs
@@ -9,81 +9,54 @@ mod cli_tests {
 		#[test]
 		fn it_check_passes_without_args() {
 			env::set_var("PRDOC_DIR", "tests/data/all");
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("check").assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_number_when_valid() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.args(["check", "-d", "../tests/data/some", "-n", "1234"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_number_when_invalid() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.args(["check", "-d", "../tests/data/some", "-n", "1"]).assert();
 			assert.failure().code(exitcode::DATAERR);
 		}
 
 		#[test]
 		fn it_check_with_file_when_valid() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert =
-				cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let assert = cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_file_and_dir_when_valid() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd
-				.args([
-					"check",
-					"-d",
-					"../tests/data/some",
-					"-f",
-					"pr_1234_some_test_minimal.prdoc",
-				])
-				.assert();
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let assert =
+				cmd.args(["check", "-d", "../tests/data/some", "-f", "pr_1234_some_test_minimal.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_list_all() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd
-				.args([
-					"check",
-					"-d",
-					"../tests/data/all",
-					"--list",
-					"../tests/data/lists/simple/all_good.txt",
-				])
+				.args(["check", "-d", "../tests/data/all", "--list", "../tests/data/lists/simple/all_good.txt"])
 				.assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_list_some() {
-			let mut cmd =
-				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd
-				.args([
-					"check",
-					"-d",
-					"../tests/data/some",
-					"--list",
-					"../tests/data/lists/simple/some_good.txt",
-				])
+				.args(["check", "-d", "../tests/data/some", "--list", "../tests/data/lists/simple/some_good.txt"])
 				.assert();
 			assert.failure().code(exitcode::DATAERR);
 		}

--- a/cli/tests/check.rs
+++ b/cli/tests/check.rs
@@ -2,8 +2,8 @@
 mod cli_tests {
 	#[cfg(test)]
 	mod check {
-		use std::env;
 		use assert_cmd::Command;
+		use std::env;
 
 		#[test]
 		fn it_check_passes_without_args() {

--- a/cli/tests/check.rs
+++ b/cli/tests/check.rs
@@ -2,58 +2,88 @@
 mod cli_tests {
 	#[cfg(test)]
 	mod check {
+		use std::env;
+
 		use assert_cmd::Command;
 
 		#[test]
 		fn it_check_passes_without_args() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			env::set_var("PRDOC_DIR", "tests/data/all");
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("check").assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_number_when_valid() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.args(["check", "-d", "../tests/data/some", "-n", "1234"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_number_when_invalid() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.args(["check", "-d", "../tests/data/some", "-n", "1"]).assert();
 			assert.failure().code(exitcode::DATAERR);
 		}
 
 		#[test]
 		fn it_check_with_file_when_valid() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let assert =
+				cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_file_and_dir_when_valid() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert =
-				cmd.args(["check", "-d", "../tests/data/some", "-f", "pr_1234_some_test_minimal.prdoc"]).assert();
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let assert = cmd
+				.args([
+					"check",
+					"-d",
+					"../tests/data/some",
+					"-f",
+					"pr_1234_some_test_minimal.prdoc",
+				])
+				.assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_list_all() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd
-				.args(["check", "-d", "../tests/data/all", "--list", "../tests/data/lists/simple/all_good.txt"])
+				.args([
+					"check",
+					"-d",
+					"../tests/data/all",
+					"--list",
+					"../tests/data/lists/simple/all_good.txt",
+				])
 				.assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_check_with_list_some() {
-			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
+			let mut cmd =
+				Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd
-				.args(["check", "-d", "../tests/data/some", "--list", "../tests/data/lists/simple/some_good.txt"])
+				.args([
+					"check",
+					"-d",
+					"../tests/data/some",
+					"--list",
+					"../tests/data/lists/simple/some_good.txt",
+				])
 				.assert();
 			assert.failure().code(exitcode::DATAERR);
 		}

--- a/cli/tests/check.rs
+++ b/cli/tests/check.rs
@@ -3,7 +3,6 @@ mod cli_tests {
 	#[cfg(test)]
 	mod check {
 		use std::env;
-
 		use assert_cmd::Command;
 
 		#[test]
@@ -30,6 +29,8 @@ mod cli_tests {
 
 		#[test]
 		fn it_check_with_file_when_valid() {
+			env::set_var("PRDOC_DIR", "tests/data/all");
+
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.args(["check", "-f", "../some/pr_1234_some_test_minimal.prdoc"]).assert();
 			assert.success().code(exitcode::OK);

--- a/cli/tests/generate.rs
+++ b/cli/tests/generate.rs
@@ -14,7 +14,7 @@ mod cli_tests {
 		#[test]
 		fn it_generate_with_number() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.args(["generate", "-o", "/tmp", "42"]).assert();
+			let assert = cmd.args(["generate", "--dry-run", "42"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 	}

--- a/cli/tests/generate.rs
+++ b/cli/tests/generate.rs
@@ -14,7 +14,7 @@ mod cli_tests {
 		#[test]
 		fn it_generate_with_number() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.args(["generate", "42"]).assert();
+			let assert = cmd.args(["generate", "-o", "/tmp", "42"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 	}

--- a/cli/tests/load.rs
+++ b/cli/tests/load.rs
@@ -2,10 +2,14 @@
 mod cli_tests {
 	#[cfg(test)]
 	mod check {
+		use std::env;
+
 		use assert_cmd::Command;
 
 		#[test]
 		fn it_loads_one_file() {
+			env::set_var("PRDOC_DIR", "tests/data/all");
+
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("load").args(["--file", "pr_1237.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
@@ -13,6 +17,7 @@ mod cli_tests {
 
 		#[test]
 		fn it_loads_one_by_number() {
+			env::set_var("PRDOC_DIR", "tests/data/all");
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("load").args(["-n", "1237"]).assert();
 			assert.success().code(exitcode::OK);
@@ -20,6 +25,7 @@ mod cli_tests {
 
 		#[test]
 		fn it_loads_some_by_number() {
+			env::set_var("PRDOC_DIR", "tests/data/all");
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
 			let assert = cmd.arg("load").args(["-n", "1234", "-n", "1237"]).assert();
 			assert.success().code(exitcode::OK);

--- a/cli/tests/load.rs
+++ b/cli/tests/load.rs
@@ -7,21 +7,21 @@ mod cli_tests {
 		#[test]
 		fn it_loads_one_file() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.arg("load").args(["--file", "../tests/data/all/pr_1237.prdoc"]).assert();
+			let assert = cmd.arg("load").args(["--file", "pr_1237.prdoc"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_loads_one_by_number() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.arg("load").args(["-d", "../tests/data/all", "-n", "1237"]).assert();
+			let assert = cmd.arg("load").args(["-n", "1237"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 
 		#[test]
 		fn it_loads_some_by_number() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed getting test bin");
-			let assert = cmd.arg("load").args(["-d", "../tests/data/all", "-n", "1234", "-n", "1237"]).assert();
+			let assert = cmd.arg("load").args(["-n", "1234", "-n", "1237"]).assert();
 			assert.success().code(exitcode::OK);
 		}
 

--- a/template.prdoc
+++ b/template.prdoc
@@ -5,7 +5,8 @@ title: ...
 
 doc:
   - audience: Core Dev
-    description: ...
+    description: |
+      ...
 
 migrations:
   db: []


### PR DESCRIPTION
Replace --save by --dry-run in the generate command and pick an appropriate default output dir if none is provided

fix #7 