### PR TITLE
Print errors by default (log-level = info)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@ use std::{collections::HashSet, env, path::PathBuf};
 
 /// Main entry point of the cli
 fn main() -> color_eyre::Result<()> {
-	env_logger::Builder::from_env(Env::default().default_filter_or("none")).init();
+	env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 	color_eyre::install()?;
 
 	let opts: Opts = Opts::parse();

--- a/prdoclib/src/commands/check.rs
+++ b/prdoclib/src/commands/check.rs
@@ -6,7 +6,7 @@ use crate::{
 	config::PRDocConfig,
 	doc_filename::DocFileName,
 	docfile::DocFile,
-	error::{self},
+	error::{self, PRdocLibError},
 	prdoc_source::PRDocSource,
 	schema::Schema,
 	utils::{get_numbers_from_file, get_project_root},
@@ -56,6 +56,11 @@ impl CheckCmd {
 								log::debug!("Loading was OK");
 								(number.into(), true)
 							},
+							Err(PRdocLibError::ValidationErrors(validation)) => {
+								log::info!("errors: {:#?}", validation.errors);
+								log::info!("missing: {:#?}", validation.missing);
+								(number.into(), false)
+							},
 							Err(e) => {
 								log::error!("Loading the schema failed:");
 								log::error!("{e:?}");
@@ -64,7 +69,7 @@ impl CheckCmd {
 						}
 					},
 					Err(e) => {
-						log::warn!("{e:?}");
+						log::error!("{e:?}");
 						(number.into(), false)
 					},
 				}

--- a/prdoclib/src/schema.rs
+++ b/prdoclib/src/schema.rs
@@ -74,10 +74,8 @@ impl Schema {
 		let validation_result_strict = validation.is_strictly_valid();
 
 		if !(validation_result && validation_result_strict) {
-			log::warn!("validation_result: {validation_result}");
-			log::warn!("validation_result_strict: {validation_result_strict}");
-			log::warn!("errors: {:#?}", validation.errors);
-			log::warn!("missing: {:#?}", validation.missing);
+			log::debug!("validation_result: {validation_result}");
+			log::debug!("validation_result_strict: {validation_result_strict}");
 			return Err(PRdocLibError::ValidationErrors(validation))
 		}
 


### PR DESCRIPTION
When checking prdoc files, I am interested in the actual errors. They are already printed,
but default log level is none. IMO it should be info.

Example output after change:
```
[2024-02-26T08:42:53Z INFO  prdoclib::commands::check] Checking directory prdoc
[2024-02-26T08:42:53Z INFO  prdoclib::commands::check] Using schema: /Users/sebastian/work/repos/polkadot-sdk/prdoc/schema_user.json
[2024-02-26T08:42:53Z INFO  prdoclib::commands::check] errors: [
        Properties {
            path: "",
            detail: "Additional property 'tle' is not allowed",
        },
        Required {
            path: "/title",
        },
    ]
[2024-02-26T08:42:53Z INFO  prdoclib::commands::check] missing: []
[2024-02-26T08:42:53Z ERROR prdoclib::commands::check] NumberNotFound(3002)
PR #3243 -> ERR
PR #3002 -> ERR
Checked 2 files.
```