### PR TITLE
Printing PR number for invalid prdoc files in `scan`

### DIFF
--- a/prdoclib/src/commands/load.rs
+++ b/prdoclib/src/commands/load.rs
@@ -53,7 +53,7 @@ impl LoadCmd {
 						let yaml = self.schema.load(&file);
 
 						if let Ok(value) = yaml {
-							Some(DocFileWrapper::new(file, filename, value))
+							Some(DocFileWrapper::new(file, filename, Some(value)))
 						} else {
 							global_result &= false;
 							None
@@ -74,7 +74,7 @@ impl LoadCmd {
 	/// Load one file and returns a wrapper
 	pub fn load_file(&self, file: &PathBuf) -> Result<DocFileWrapper> {
 		let filename = DocFileName::try_from(file)?;
-		let value = self.schema.load(&file)?;
+		let value = self.schema.load(&file).ok();
 		let wrapper = DocFileWrapper::new(file.clone(), filename, value);
 		Ok(wrapper)
 	}
@@ -103,7 +103,7 @@ impl LoadCmd {
 				if let Ok(filename) = filename_maybe {
 					let yaml = self.schema.load(&file);
 					if let Ok(value) = yaml {
-						let wrapper = DocFileWrapper::new(file.clone(), filename, value);
+						let wrapper = DocFileWrapper::new(file.clone(), filename, Some(value));
 
 						global_result &= true;
 						log::debug!("OK  {}", file.display());

--- a/prdoclib/src/docfile_wrapper.rs
+++ b/prdoclib/src/docfile_wrapper.rs
@@ -19,12 +19,12 @@ pub struct DocFileWrapper {
 	pub doc_filename: DocFileName,
 
 	/// The content of the PRDoc
-	pub content: Value,
+	pub content: Option<Value>,
 }
 
 impl DocFileWrapper {
 	/// Create a new wrapper
-	pub fn new(file: PathBuf, filename: DocFileName, content: Value) -> Self {
+	pub fn new(file: PathBuf, filename: DocFileName, content: Option<Value>) -> Self {
 		let file = file.canonicalize().expect("Canonicalize works");
 		Self { file, doc_filename: filename, content }
 	}


### PR DESCRIPTION
Before this change, prdoc scan --all would return "n/a" for PR numbers of invalid files, even if file was named correctly, like `prdoc/pr_1946.prdoc`.
This removes the requirement for file to be valid in order to get PR number from filename.

Before: <img width="870" alt="Screen Shot 2024-06-27 at 10 09 42" src="https://github.com/paritytech/prdoc/assets/588262/f5273913-eb6f-4238-be3a-196ce11917f0">
After: 
<img width="870" alt="Screen Shot 2024-06-27 at 10 10 20" src="https://github.com/paritytech/prdoc/assets/588262/777b556e-4956-4173-bbef-9574334aadf1">

Fixes #17 