### PR TITLE
Print correct error in case of missing tempalte file

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> color_eyre::Result<()> {
 			match GenerateCmd::run(cmd_opts.dry_run, cmd_opts.number, None, Some(dir), template_path) {
 				Ok(_) => Ok(()),
 				Err(e) => {
-					eprint!("{e:?}");
+					log::error!("{e}");
 					std::process::exit(exitcode::IOERR);
 				}
 			}

--- a/prdoclib/src/docfile.rs
+++ b/prdoclib/src/docfile.rs
@@ -57,7 +57,12 @@ impl DocFile {
 			repo_root.join(file)
 		};
 
-		Ok(fs::read_to_string(template_file)?)
+		match fs::read_to_string(&template_file) {
+			Ok(res) => Ok(res),
+			Err(ref e) if e.kind() == std::io::ErrorKind::NotFound =>
+				Err(error::PRdocLibError::MissingTemplateFile(template_file)),
+			Err(e) => Err(error::PRdocLibError::IO(e)),
+		}
 	}
 
 	/// Returns an iterator if the `dir` was a valid directory or an error otherwise.

--- a/prdoclib/src/error.rs
+++ b/prdoclib/src/error.rs
@@ -41,6 +41,9 @@ pub enum PRdocLibError {
 	#[error("No valid config found")]
 	MissingConfig,
 
+	#[error("Template file at {0} was not found")]
+	MissingTemplateFile(PathBuf),
+
 	#[error("No valid file found in {0}")]
 	NoValidFileFound(PathBuf),
 


### PR DESCRIPTION
Previously it just printed "No such file or directory" without any indication what file is actually missing

Fixes #20

Before: 
<img width="869" alt="Screen Shot 2024-06-27 at 11 28 23" src="https://github.com/paritytech/prdoc/assets/588262/8c347dac-1b9f-4e0b-b819-3f8f84eccccd">
After:
<img width="862" alt="Screen Shot 2024-06-27 at 11 25 34" src="https://github.com/paritytech/prdoc/assets/588262/7b5f7312-a255-421c-9c1b-ace852dc0e35">
